### PR TITLE
보기 안 좋은 링크 힌트

### DIFF
--- a/namuwiki-unfold.user.js
+++ b/namuwiki-unfold.user.js
@@ -37,18 +37,69 @@ function namuwiki_fold() {
     });
 }
 
+function hintUglyLinks() {
+    let contents = $('.wiki-link-internal').parent().contents();
+    let internalLinkChecker = (elem) => {
+        return (
+            elem &&
+            elem.nodeName === 'A' &&
+            elem.classList.contains('wiki-link-internal') &&
+            elem.querySelector('img') === null
+        );
+    };
+    let buffer = [];
+    for (let i = 0; i < contents.length; i += 1) {
+        let content = contents[i];
+        if (internalLinkChecker(content)) {
+            if (content.parentNode.querySelectorAll('a.wiki-link-internal') < 2) {
+                continue;
+            }
+
+            if (internalLinkChecker(contents[i+1])) {
+                buffer.push(content.title);
+            }
+            else if (internalLinkChecker(contents[i-1])){
+                buffer.push(content.title);
+                let newElem = $('<span>');
+                newElem.addClass('namu-hint-ugly-links');
+                newElem.css(
+                    'cssText',
+                    'background:#EEE;padding:1px;border:1px solid #CCC;color:#666'
+                );
+                newElem.text(buffer.join(', '));
+                newElem.insertAfter($(content));
+                buffer = [];
+            }
+        }
+    }
+}
+
+function removeHints() {
+    $('span.namu-hint-ugly-links').remove();
+}
+
+function fold() {
+    namuwiki_fold();
+    removeHints();
+}
+
+function unfold() {
+    namuwiki_unfold();
+    hintUglyLinks();
+}
+
 document.addEventListener('keydown', function(e) {
     if (e.shiftKey && e.keyCode == 51) {
         if ($('.wiki-inner-content').attr('data-namuwiki-unfold') == 'true') {
-            namuwiki_fold();
+            fold();
         } else {
-            namuwiki_unfold();
+            unfold();
         }
     }
 }, true);
 
 $(document).on('pjax:end', function(){
-    namuwiki_unfold();
-})
+    unfold();
+});
 
-namuwiki_unfold();
+unfold();


### PR DESCRIPTION
`[[some_link|이런]][[another_link|망할]][[wow|링크를]]` 보기 좋게 해 줍니다.

Before:
![screenshot from 2017-09-17 01-36-07](https://user-images.githubusercontent.com/5047683/30514014-b007472a-9b48-11e7-8710-c509498ecd27.png)
After:
![screenshot from 2017-09-17 01-36-28](https://user-images.githubusercontent.com/5047683/30514016-b1a166b0-9b48-11e7-93f9-8c42b4e0e7e2.png)
